### PR TITLE
Fixed parsing and evaluation problems with wildcard namespace and nodeNames

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -81,7 +81,7 @@ wgxpath.Lexer.tokenize = function(source) {
  * @private
  */
 wgxpath.Lexer.TOKEN_ = new RegExp(
-    '\\$?(?:(?![0-9-])(?:\\*|[\\w-\\.]+):)?(?![0-9-])(?:\\*|[\\w-\\.]+)' +
+    '\\$?(?:(?![0-9-\\.])(?:\\*|[\\w-\\.]+):)?(?![0-9-\\.])(?:\\*|[\\w-\\.]+)' +
         // Nodename or wildcard[*] (possibly with namespace or wildcard[*]) or variable.
     '|\\/\\/' + // Double slash.
     '|\\.\\.' + // Double dot.

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -81,7 +81,7 @@ wgxpath.Lexer.tokenize = function(source) {
  * @private
  */
 wgxpath.Lexer.TOKEN_ = new RegExp(
-    '\\$?(?:(?![0-9-])[\\w-\\*]+:)?(?![0-9-])[\\w-\\*]+' +
+    '\\$?(?:(?![0-9-])(?:\\*|[\\w-]+):)?(?![0-9-])(?:\\*|[\\w-]+)' +
         // Nodename or wildcard[*] (possibly with namespace or wildcard[*]) or variable.
     '|\\/\\/' + // Double slash.
     '|\\.\\.' + // Double dot.

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -81,7 +81,7 @@ wgxpath.Lexer.tokenize = function(source) {
  * @private
  */
 wgxpath.Lexer.TOKEN_ = new RegExp(
-    '\\$?(?:(?![0-9-])(?:\\*|[\\w-]+):)?(?![0-9-])(?:\\*|[\\w-]+)' +
+    '\\$?(?:(?![0-9-])(?:\\*|[\\w-\\.]+):)?(?![0-9-])(?:\\*|[\\w-\\.]+)' +
         // Nodename or wildcard[*] (possibly with namespace or wildcard[*]) or variable.
     '|\\/\\/' + // Double slash.
     '|\\.\\.' + // Double dot.

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -81,8 +81,8 @@ wgxpath.Lexer.tokenize = function(source) {
  * @private
  */
 wgxpath.Lexer.TOKEN_ = new RegExp(
-    '\\$?(?:(?![0-9-])[\\w-]+:)?(?![0-9-])[\\w-]+' +
-        // Nodename (possibly with namespace) or variable.
+    '\\$?(?:(?![0-9-])[\\w-\\*]+:)?(?![0-9-])[\\w-\\*]+' +
+        // Nodename or wildcard[*] (possibly with namespace or wildcard[*]) or variable.
     '|\\/\\/' + // Double slash.
     '|\\.\\.' + // Double dot.
     '|::' + // Double colon.

--- a/src/nameTest.js
+++ b/src/nameTest.js
@@ -54,12 +54,20 @@ wgxpath.NameTest = function(name, opt_namespaceUri) {
    */
   this.name_ = name.toLowerCase();
 
+  var defaultNamespace;
+  if(this.name_ == wgxpath.NameTest.WILDCARD) {
+    // wildcard names default to wildcard namespace
+    defaultNamespace = wgxpath.NameTest.WILDCARD;
+  } else {
+    // defined names default to html namespace
+    defaultNamespace = wgxpath.NameTest.HTML_NAMESPACE_URI_;
+  }
   /**
    * @type {string}
    * @private
    */
-  this.namespaceUri_ = opt_namespaceUri ? opt_namespaceUri.toLowerCase() :
-      wgxpath.NameTest.HTML_NAMESPACE_URI_;
+  this.namespaceUri_ = opt_namespaceUri ? opt_namespaceUri.toLowerCase() : defaultNamespace;
+
 };
 
 
@@ -72,6 +80,15 @@ wgxpath.NameTest = function(name, opt_namespaceUri) {
  */
 wgxpath.NameTest.HTML_NAMESPACE_URI_ = 'http://www.w3.org/1999/xhtml';
 
+ /**
+  * Wildcard namespace which matches any namespace
+  *
+  * @const
+  * @type {string}
+  * @private
+  */
+ wgxpath.NameTest.WILDCARD = '*';
+
 
 /**
  * @override
@@ -82,12 +99,21 @@ wgxpath.NameTest.prototype.matches = function(node) {
       type != goog.dom.NodeType.ATTRIBUTE) {
     return false;
   }
-  if (this.name_ != '*' && this.name_ != node.nodeName.toLowerCase()) {
+  console.log("Name matches? '"+this.name_+"' - '"+node.nodeName.toLowerCase()+"'");
+
+  // check if names dont match, if this is a wildcard then
+  if (this.name_ != wgxpath.NameTest.WILDCARD && this.name_ != node.nodeName.toLowerCase()) {
     return false;
   } else {
-    var namespaceUri = node.namespaceURI ? node.namespaceURI.toLowerCase() :
-        wgxpath.NameTest.HTML_NAMESPACE_URI_;
-    return this.namespaceUri_ == namespaceUri;
+    // wildcard namespace, it matches
+    if(this.namespaceUri_ == wgxpath.NameTest.WILDCARD) {
+      return true;
+    } else {
+
+      var namespaceUri = node.namespaceURI ? node.namespaceURI.toLowerCase() :
+          wgxpath.NameTest.HTML_NAMESPACE_URI_;
+      return this.namespaceUri_ == namespaceUri;
+    }
   }
 };
 

--- a/src/nameTest.js
+++ b/src/nameTest.js
@@ -85,7 +85,7 @@ wgxpath.NameTest.HTML_NAMESPACE_URI_ = 'http://www.w3.org/1999/xhtml';
   *
   * @const
   * @type {string}
-  * @private
+  * @public
   */
  wgxpath.NameTest.WILDCARD = '*';
 
@@ -99,10 +99,9 @@ wgxpath.NameTest.prototype.matches = function(node) {
       type != goog.dom.NodeType.ATTRIBUTE) {
     return false;
   }
-  console.log("Name matches? '"+this.name_+"' - '"+node.nodeName.toLowerCase()+"'");
 
   // check if names dont match, if this is a wildcard then
-  if (this.name_ != wgxpath.NameTest.WILDCARD && this.name_ != node.nodeName.toLowerCase()) {
+  if (this.name_ != wgxpath.NameTest.WILDCARD && this.name_ != node.localName.toLowerCase()) {
     return false;
   } else {
     // wildcard namespace, it matches

--- a/src/parser.js
+++ b/src/parser.js
@@ -270,9 +270,14 @@ wgxpath.Parser.prototype.parseNameTest_ = function() {
     return new wgxpath.NameTest(name);
   } else {
     var namespacePrefix = name.substring(0, colonIndex);
-    var namespaceUri = this.nsResolver_(namespacePrefix);
-    if (!namespaceUri) {
-      throw Error('Namespace prefix not declared: ' + namespacePrefix);
+    var namespaceUri;
+    if(namespacePrefix == wgxpath.NameTest.WILDCARD) {
+      namespaceUri = wgxpath.NameTest.WILDCARD;
+    } else {
+      namespaceUri = this.nsResolver_(namespacePrefix);
+      if (!namespaceUri) {
+        throw Error('Namespace prefix not declared: ' + namespacePrefix);
+      }
     }
     name = name.substr(colonIndex + 1);
     return new wgxpath.NameTest(name, namespaceUri);
@@ -388,12 +393,8 @@ wgxpath.Parser.prototype.parseStep_ = function(op) {
 
     // Grab the test.
     token = this.lexer_.peek();
-    if (!/(?![0-9])[\w]/.test(token.charAt(0))) {
-      if (token == '*') {
-        test = this.parseNameTest_();
-      } else {
-        throw Error('Bad token: ' + this.lexer_.next());
-      }
+    if (!/(?![0-9])[\w\*]/.test(token.charAt(0))) {
+      throw Error('Bad token: ' + this.lexer_.next());
     } else {
       if (this.lexer_.peek(1) == '(') {
         if (!wgxpath.KindTest.isValidType(token)) {

--- a/src/wgxpath.js
+++ b/src/wgxpath.js
@@ -222,7 +222,7 @@ wgxpath.XPathNSResolver_ = function(node) {
 
 
 /**
- * Installs the library. This is a noop if native XPath is available or the 2nd parameter is true.
+ * Installs the library. This is a noop if native XPath is available and the 2nd parameter (force_install) is false/undefined.
  *
  * @param {Window=} opt_win The window to install the library on.
  * @param {boolean=} force_install Overwrites any existing method if evaluate on the document.

--- a/src/wgxpath.js
+++ b/src/wgxpath.js
@@ -97,6 +97,7 @@ wgxpath.XPathExpression_ = function(expr, nsResolver) {
   if (!lexer.empty()) {
     throw Error('Bad token: ' + lexer.next());
   }
+  
   this['evaluate'] = function(node, type) {
     var value = gexpr.evaluate(new wgxpath.Context(node));
     return new wgxpath.XPathResult_(value, type);
@@ -221,16 +222,17 @@ wgxpath.XPathNSResolver_ = function(node) {
 
 
 /**
- * Installs the library. This is a noop if native XPath is available.
+ * Installs the library. This is a noop if native XPath is available or the 2nd parameter is true.
  *
  * @param {Window=} opt_win The window to install the library on.
+ * @param {boolean=} force_install Overwrites any existing method if evaluate on the document.
  */
-wgxpath.install = function(opt_win) {
+wgxpath.install = function(opt_win, force_install) {
   var win = opt_win || goog.global;
   var doc = win.document;
 
-  // Installation is a noop if native XPath is available.
-  if (doc['evaluate']) {
+  // Installation is a noop if native XPath is available unless you want to force install
+  if (doc['evaluate'] && !force_install) {
     return;
   }
 


### PR DESCRIPTION
Added proper matching and parsing for wildcard namespaces and wildcard names such as:

`*:nodeName`
`prefix:*`
`*:*`
`*`

Given this xml document.
```xml
 <MyDocument xmlns="http://namespace1/" xmlns:ns2="http://namespace2/">
    <ParentNode>
        <ChildNode />
        <ChildNode1>
            <innerChild></innerChild>
        </ChildNode1>
        <ns2:ChildNode1>
            <innerChild></innerChild>
        </ns2:ChildNode1>
        <ns2:Namespace2Child />
    </ParentNode>
</MyDocument>
```

and this namespace resolver
```javascript
var nsResolver = function(n) {
    if(n == 'ns2') {
        return 'http://namespace2/';
    } else if(n == 'a') {
        return 'http://namespace1/';
    }
};
```

The following statements will now operate correctly, below is an ouput of each xpath query executed with the result type of ORDERED_NODE_ITERATOR_TYPE and its iterator spit out.
 
```text
Test wildcard all
Testing '/a:MyDocument/a:ParentNode/*'======================================================
<ChildNode>​</ChildNode>​
<ChildNode1>​…​</ChildNode1>​
<ns2:ChildNode1>​…​</ns2:ChildNode1>​
<ns2:Namespace2Child>​</ns2:Namespace2Child>​
===========================================================================================

Test wildcard namespaces
Testing '/a:MyDocument/a:ParentNode/*:ChildNode'===========================================
<ChildNode>​</ChildNode>​
===========================================================================================
Testing '/a:MyDocument/a:ParentNode/*:ChildNode1'==========================================
<ChildNode1>​…​</ChildNode1>​
<ns2:ChildNode1>​…​</ns2:ChildNode1>​
===========================================================================================

Test wildcard node names
Testing '/a:MyDocument/a:ParentNode/a:*'===================================================
<ChildNode>​</ChildNode>​
<ChildNode1>​…​</ChildNode1>​
===========================================================================================
Testing '/a:MyDocument/a:ParentNode/ns2:*'=================================================
<ns2:ChildNode1>​…​</ns2:ChildNode1>​
<ns2:Namespace2Child>​</ns2:Namespace2Child>​
===========================================================================================
```

Wildcard namespace prefixes are actually only supported in XPath 2.0 however I build them in forgetting that they wernt part of the 1.0 spec and decided not to remove them unless you dont want them supported.


I made one other change with the `install` method, I added a 2nd optional `boolean` parameter called `force_overwrite` which if set to true (default false) will overwrite any existing `evaluate` method so you can keep the xpath implementation standardized across multiple platforms. This definitely helps me when testing. If you disagree with that parameter I wouldnt mind if it doesnt get merged.


I would really like to get these changes merged into the trunk ASAP while its on my mind so if you have any problems with the changes I made let me know.