### PR TITLE
{} vs [] for use with non-number indices

### DIFF
--- a/src/functionCall.js
+++ b/src/functionCall.js
@@ -491,7 +491,7 @@ wgxpath.FunctionCall.Func = {
         var str2 = expr2.asString(ctx);
         var str3 = expr3.asString(ctx);
 
-        var map = [];
+        var map = {};
         for (var i = 0; i < str2.length; i++) {
           var ch = str2.charAt(i);
           if (!(ch in map)) {


### PR DESCRIPTION
Prepare for tightening of the Array definition which would
make this warning an error.