### PR TITLE
add force key for replace native xpath

### DIFF
--- a/src/wgxpath.js
+++ b/src/wgxpath.js
@@ -225,12 +225,12 @@ wgxpath.XPathNSResolver_ = function(node) {
  *
  * @param {Window=} opt_win The window to install the library on.
  */
-wgxpath.install = function(opt_win) {
+wgxpath.install = function(opt_win, force) {
   var win = opt_win || goog.global;
   var doc = win.document;
 
   // Installation is a noop if native XPath is available.
-  if (doc['evaluate']) {
+  if (doc['evaluate'] && !force) {
     return;
   }
 


### PR DESCRIPTION
Hey, guys! How about to add the `force` key to install function?
That's may be useful in some cases like this: http://stackoverflow.com/questions/21472896/android-4-3-default-browser-xmldoc-evaluate-throws-invalid-expression-err-dom