### PR TITLE
Fix compare_ in binaryExpr.js

### DIFF
--- a/src/binaryExpr.js
+++ b/src/binaryExpr.js
@@ -147,8 +147,13 @@ wgxpath.BinaryExpr.compare_ = function(comp, lhs, rhs, ctx, opt_equChk) {
         default:
           throw Error('Illegal primitive type for comparison.');
       }
-      if (comp(stringValue,
-          /** @type {(string|number|boolean)} */ (primitive))) {
+      if (nodeset == left &&
+          comp(stringValue,
+              /** @type {(string|number|boolean)} */ (primitive))) {
+        return true;
+      } else if (nodeset == right &&
+          comp(/** @type {(string|number|boolean)} */ (primitive),
+              stringValue)) {
         return true;
       }
     }

--- a/src/binaryExpr_test.js
+++ b/src/binaryExpr_test.js
@@ -37,6 +37,7 @@ goog.require('wgxpath.Expr');
 goog.require('wgxpath.Number');
 
 
+// TODO(moz): Add tests involving wgxpath.NodeSet.
 function assertBinaryExprEvaluatesTo(expected, op, left, right) {
   var expr = new wgxpath.BinaryExpr(op, new wgxpath.Number(left),
                                     new wgxpath.Number(right));


### PR DESCRIPTION
binaryExpr_test.js does not test this fix yet. We will need a
binaryExpr_test_dom.html file to support test cases involving
wgxpath.NodeSet. Since there is no easy way to run the unit tests
from the open source repository, tests will be added later.
    
Fixes #26.