### PR TITLE
Add matching and parsing for wildcard namespaces and wildcard names

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -81,8 +81,9 @@ wgxpath.Lexer.tokenize = function(source) {
  * @private
  */
 wgxpath.Lexer.TOKEN_ = new RegExp(
-    '\\$?(?:(?![0-9-])[\\w-]+:)?(?![0-9-])[\\w-]+' +
-        // Nodename (possibly with namespace) or variable.
+    '\\$?(?:(?![0-9-])(?:\\*|[\\w-]+):)?(?![0-9-])(?:\\*|[\\w-]+)' +
+        // Nodename or wildcard[*] (possibly with namespace or wildcard[*]) or
+        // variable.
     '|\\/\\/' + // Double slash.
     '|\\.\\.' + // Double dot.
     '|::' + // Double colon.

--- a/src/nameTest.js
+++ b/src/nameTest.js
@@ -54,12 +54,21 @@ wgxpath.NameTest = function(name, opt_namespaceUri) {
    */
   this.name_ = name.toLowerCase();
 
+  var defaultNamespace;
+  if (this.name_ == wgxpath.NameTest.WILDCARD) {
+    // Wildcard names default to wildcard namespace.
+    defaultNamespace = wgxpath.NameTest.WILDCARD;
+  } else {
+    // Defined names default to html namespace.
+    defaultNamespace = wgxpath.NameTest.HTML_NAMESPACE_URI_;
+  }
   /**
    * @type {string}
    * @private
    */
   this.namespaceUri_ = opt_namespaceUri ? opt_namespaceUri.toLowerCase() :
-      wgxpath.NameTest.HTML_NAMESPACE_URI_;
+      defaultNamespace;
+
 };
 
 
@@ -72,6 +81,15 @@ wgxpath.NameTest = function(name, opt_namespaceUri) {
  */
 wgxpath.NameTest.HTML_NAMESPACE_URI_ = 'http://www.w3.org/1999/xhtml';
 
+ /**
+  * Wildcard namespace which matches any namespace
+  *
+  * @const
+  * @type {string}
+  * @public
+  */
+ wgxpath.NameTest.WILDCARD = '*';
+
 
 /**
  * @override
@@ -82,12 +100,17 @@ wgxpath.NameTest.prototype.matches = function(node) {
       type != goog.dom.NodeType.ATTRIBUTE) {
     return false;
   }
-  if (this.name_ != '*' && this.name_ != node.nodeName.toLowerCase()) {
+  if (this.name_ != wgxpath.NameTest.WILDCARD &&
+      this.name_ != node.localName.toLowerCase()) {
     return false;
   } else {
-    var namespaceUri = node.namespaceURI ? node.namespaceURI.toLowerCase() :
-        wgxpath.NameTest.HTML_NAMESPACE_URI_;
-    return this.namespaceUri_ == namespaceUri;
+    if (this.namespaceUri_ == wgxpath.NameTest.WILDCARD) {
+      return true;
+    } else {
+      var namespaceUri = node.namespaceURI ? node.namespaceURI.toLowerCase() :
+          wgxpath.NameTest.HTML_NAMESPACE_URI_;
+      return this.namespaceUri_ == namespaceUri;
+    }
   }
 };
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -270,9 +270,14 @@ wgxpath.Parser.prototype.parseNameTest_ = function() {
     return new wgxpath.NameTest(name);
   } else {
     var namespacePrefix = name.substring(0, colonIndex);
-    var namespaceUri = this.nsResolver_(namespacePrefix);
-    if (!namespaceUri) {
-      throw Error('Namespace prefix not declared: ' + namespacePrefix);
+    var namespaceUri;
+    if (namespacePrefix == wgxpath.NameTest.WILDCARD) {
+      namespaceUri = wgxpath.NameTest.WILDCARD;
+    } else {
+      namespaceUri = this.nsResolver_(namespacePrefix);
+      if (!namespaceUri) {
+        throw Error('Namespace prefix not declared: ' + namespacePrefix);
+      }
     }
     name = name.substr(colonIndex + 1);
     return new wgxpath.NameTest(name, namespaceUri);
@@ -388,12 +393,8 @@ wgxpath.Parser.prototype.parseStep_ = function(op) {
 
     // Grab the test.
     token = this.lexer_.peek();
-    if (!/(?![0-9])[\w]/.test(token.charAt(0))) {
-      if (token == '*') {
-        test = this.parseNameTest_();
-      } else {
-        throw Error('Bad token: ' + this.lexer_.next());
-      }
+    if (!/(?![0-9])[\w\*]/.test(token.charAt(0))) {
+      throw Error('Bad token: ' + this.lexer_.next());
     } else {
       if (this.lexer_.peek(1) == '(') {
         if (!wgxpath.KindTest.isValidType(token)) {


### PR DESCRIPTION
Eg:
```
  *:nodeName
  prefix:*
  *:*
  *
```
TODO(moz): We will need more tests for these.

Originally authored by @nedjs and modified by @Dominator008.

Fixes #22.