### PR TITLE
Build with Gulp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+node_modules/
 wgxpath.install.js

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Download the latest <a href="https://github.com/google/wicked-good-xpath/release
 ```
 Then call `wgxpath.install()` from your JavaScript code, which will ensure <a href="http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator-evaluate">`document.evaluate`</a>, the XPath evaluation function, is defined on the window object. To install the library on a different window, pass that window as an argument to the install function.
 
+## Building it Yourself
+We use Gulp:
+```
+npm install
+gulp
+```
+You can also run `src/compile.sh` if you want to use different versions of
+Closure Compiler / Closure Library.
+
 ## History
 Wicked Good XPath started as a <a href="https://developers.google.com/closure/">Google Closure</a> port of the <a href="http://coderepos.org/share/wiki/JavaScript-XPath">JavaScript-XPath</a> project by Cybozu Labs. At the time, JavaScript-XPath was the fastest JavaScript implementation of XPath available --- a whopping 10 times faster than Google's own AJAXSLT --- which made it a popular choice, notable for frontend web testing tools like <a href="http://docs.seleniumhq.org/">Selenium</a> and <a href="https://github.com/google/puppeteer">Web Puppeteer</a>.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * The MIT License
+ *
+ * Copyright (c) 2016 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/**
+ * @fileoverview Build process for wicked-good-xpath.
+ * @author zhoumotongxue008@gmail.com (Michael Zhou)
+ */
+
+'use strict';
+
+var gulp = require('gulp');
+var closureCompiler = require('google-closure-compiler').gulp();
+
+gulp.task('compile', function() {
+  return gulp.src([
+          'src/*.js',
+          '!src/*_test.js',
+          'node_modules/google-closure-library/closure/**/*.js',
+          'node_modules/google-closure-library/closure/**/*_test.js'
+      ])
+      .pipe(closureCompiler({
+        compilation_level: 'ADVANCED',
+        dependency_mode: 'STRICT',
+        entry_point: 'goog:wgxpath',
+        language_in: 'ES6_STRICT',
+        language_out: 'ES5_STRICT',
+        js_output_file: 'wgxpath.install.js',
+        output_wrapper: '(function(){%output%}).call(this)',
+        warning_level: 'VERBOSE'
+      }))
+      .pipe(gulp.dest('./dist'));
+});
+gulp.task('default', ['compile']);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "wicked-good-xpath",
+  "description": "Pure JS implementation of the DOM Level 3 XPath specification",
+  "version": "1.2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/wicked-good-xpath"
+  },
+  "main": "wgxpath.install.js",
+  "keywords": [
+    "closure",
+    "google",
+    "html",
+    "javascript",
+    "library",
+    "parse",
+    "wgxpath",
+    "wicked-good-xpath",
+    "xpath"
+  ],
+  "author": {
+    "name": "Google Inc."
+  },
+  "contributors": [
+    {
+      "name": "Evan Thomas",
+      "email": "evanrthom@gmail.com"
+    },
+    {
+      "name": "Greg Dennis",
+      "email": "gdennis@google.com"
+    },
+    {
+      "name": "Joon Lee",
+      "email": "joonlee@google.com"
+    },
+    {
+      "name": "Michael Zhou",
+      "email": "zhoumotongxue008@gmail.com"
+    }
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/google/wicked-good-xpath/issues"
+  },
+  "homepage": "https://github.com/google/wicked-good-xpath",
+  "devDependencies": {
+    "google-closure-compiler": "20160208.1.0",
+    "google-closure-library": "20160208.0.0"
+  }
+}

--- a/src/compile.sh
+++ b/src/compile.sh
@@ -1,12 +1,27 @@
 #!/bin/sh
-python ../closure-library/closure/bin/build/closurebuilder.py \
-    --root ../closure-library \
-    --root . \
-    --namespace wgxpath \
-    --output_mode compiled \
-    --compiler_jar ../closure-compiler/build/compiler.jar \
-    --compiler_flags "--compilation_level=ADVANCED_OPTIMIZATIONS" \
-    --compiler_flags "--output_wrapper=(function(){%output%})()" \
-    --compiler_flags "--use_types_for_optimization" \
-    --compiler_flags "--warning_level=VERBOSE" \
-    > wgxpath.install.js
+#
+# Script to compile Wicked Good XPath. This script assumes that you have
+# Closure Compiler at ../../closure-compiler/build/compiler.jar and Closure
+# Library at ../../closure-library. This script is now deprecated in favor
+# of Gulp unless you are using Closure Compiler or Closure Library from HEAD.
+
+echo "Compiling Wicked Good XPath with Closure Compiler..."
+java -jar ../closure-compiler/build/compiler.jar \
+    -O ADVANCED \
+    --dependency_mode STRICT \
+    --entry_point goog:wgxpath \
+    --language_in ES6_STRICT \
+    --language_out ES5_STRICT \
+    --js 'src/*.js' \
+    --js '!src/*_test.js' \
+    --js '../closure-library/closure/**/*.js' \
+    --js '!../closure-library/closure/**/*_test.js' \
+    --js_output_file wgxpath.install.js \
+    --output_wrapper '(function(){%output%}).call(this)' \
+    --warning_level VERBOSE
+if [ $? -eq 0 ]
+then
+  echo "Compilation succeeded."
+else
+  echo "Compilation failed."
+fi


### PR DESCRIPTION
Switch from our custom src/compile.sh to using the Gulp plugin from
https://www.npmjs.com/package/google-closure-compiler so that people
don't have to download the Closure tools manually.

Mark src/compile.sh as deprecated, but keep it for people who want to
use Closure Compiler / Closure Library from HEAD.

Update README.md to include instructions for building the library.

Fixes #32.