### PR TITLE
Fix order of tests such that .style can't mutate DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wicked-good-xpath",
   "description": "Pure JS implementation of the DOM Level 3 XPath specification",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/google/wicked-good-xpath.git"

--- a/src/step.js
+++ b/src/step.js
@@ -361,8 +361,10 @@ wgxpath.Step.Axis = {
         var testName = test.getName();
         // IE8 doesn't allow access to the style attribute using getNamedItem.
         // It returns an object with nodeValue = null.
-        if (testName == 'style' && node.style &&
-            wgxpath.userAgent.IE_DOC_PRE_9) {
+        // '.style' here can mutate the DOM on some browsers (adding empty
+        // string attr) so include as last condition
+        if (testName == 'style' &&
+            wgxpath.userAgent.IE_DOC_PRE_9 && node.style) {
           nodeset.add(wgxpath.IEAttrWrapper.forStyleOf(
               /** @type {!Node} */ (node), node.sourceIndex));
           return nodeset;


### PR DESCRIPTION
In some browsers .style can mutate the DOM; this is easily remedied by switch the AND order.