### PR TITLE
Simplify condition for not testing XHTML iframe on IE < 9

### DIFF
--- a/test/xhtml_test.html
+++ b/test/xhtml_test.html
@@ -12,7 +12,7 @@
 <body>
   <script>
   // IE versions <= 8 do not support XHTML. We cannot unconditionally include
-  // this iframe, because on browsers that do not support HTML, the iframe can
+  // this iframe, because on browsers that do not support XHTML, the iframe can
   // cause a download and a dialog to appear, making the browser unresponsive.
   var SUPPORTS_XHTML = !wgxpath.test.IE_DOC_PRE_9;
   if (SUPPORTS_XHTML) {

--- a/test/xhtml_test.html
+++ b/test/xhtml_test.html
@@ -14,7 +14,7 @@
   // IE versions <= 8 do not support XHTML. We cannot unconditionally include
   // this iframe, because on browsers that do not support HTML, the iframe can
   // cause a download and a dialog to appear, making the browser unresponsive.
-  var SUPPORTS_XHTML = !goog.userAgent.IE || goog.userAgent.isVersion(9);
+  var SUPPORTS_XHTML = !wgxpath.test.IE_DOC_PRE_9;
   if (SUPPORTS_XHTML) {
     document.write('<iframe id="frame" src="xhtml_test_page.xhtml"></iframe>');
   }


### PR DESCRIPTION
This change brings the code into line with the comment about avoiding this test only in Internet Explorer 8 and below. It also takes advantage of the criteria for determining the browser version being laid out over in the tests JS file rather than recreating it in the test in the first place.