### PR TITLE
Namespaces are handled slightly wrong

### DIFF
--- a/src/nameTest.js
+++ b/src/nameTest.js
@@ -52,7 +52,7 @@ wgxpath.NameTest = function(name, opt_namespaceUri) {
    * @type {string}
    * @private
    */
-  this.name_ = name.toLowerCase();
+  this.name_ = name;
 
   var defaultNamespace;
   if (this.name_ == wgxpath.NameTest.WILDCARD) {
@@ -69,6 +69,9 @@ wgxpath.NameTest = function(name, opt_namespaceUri) {
   this.namespaceUri_ = opt_namespaceUri ? opt_namespaceUri.toLowerCase() :
       defaultNamespace;
 
+  if (this.namespaceUri_ == wgxpath.NameTest.HTML_NAMESPACE_URI_) {
+    this.name_ = this.name_.toLowerCase();
+  }
 };
 
 


### PR DESCRIPTION
* It seems like tags are always lower-cased in a path even when they're not in the HTML namespace, which should not happen [jsfiddle](https://jsfiddle.net/31xaewcv/1/)
* If no namespace is specified, only html namespaces should be matched [jsfiddle](https://jsfiddle.net/31xaewcv/)

Just comment out the `install` line vs leaving it to show the difference vs browser implementations.