### PR TITLE
Add dist/ to the repository for Bower usage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "wicked-good-xpath",
+  "version": "1.3.0",
   "description": "Pure JS implementation of the DOM Level 3 XPath specification",
   "main": "dist/wgxpath.install.js",
   "authors": [

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wicked-good-xpath",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Pure JS implementation of the DOM Level 3 XPath specification",
   "main": "dist/wgxpath.install.js",
   "authors": [

--- a/bower.json
+++ b/bower.json
@@ -40,6 +40,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "!dist/",
+    "!dist/*"
   ]
 }


### PR DESCRIPTION
Installation using "bower install --save google/wicked-good-xpath" still ignores the dist directory,
even after the following commit to close issue #44 