### PR TITLE
Explicitly require wgxpath.DataType

### DIFF
--- a/src/functionCall.js
+++ b/src/functionCall.js
@@ -39,6 +39,7 @@ goog.require('wgxpath.Expr');
 goog.require('wgxpath.Node');
 goog.require('wgxpath.NodeSet');
 goog.require('wgxpath.userAgent');
+goog.require('wgxpath.DataType');
 
 
 


### PR DESCRIPTION
Loading the library through closure-loader fails due to wgxpath.DataType not being required.  
It causes wgxpath.DataType to be undefined.