### PR TITLE
Kind test matches text() to both parsed and not parsed character nodes.

### DIFF
--- a/src/kindTest.js
+++ b/src/kindTest.js
@@ -100,7 +100,8 @@ wgxpath.KindTest.isValidType = function(typeName) {
  * @override
  */
 wgxpath.KindTest.prototype.matches = function(node) {
-  return goog.isNull(this.type_) || this.type_ == node.nodeType;
+  var efftype = node.nodeType == goog.dom.NodeType.CDATA_SECTION ? goog.dom.NodeType.TEXT : node.nodeType;
+  return goog.isNull(this.type_) || this.type_ == efftype;
 };
 
 


### PR DESCRIPTION
This is needed because, although CDATA_SECTION_NODE type is deprecated,
popular browsers still use it when building DOM from xml files. (They ought to convert 
incoming CDATA sections to TEXT_NODE but they don't.)  At the same time the built in
evaluate function in Firefox, Chrome, Safari etc. return the right results by matching text()
to both types of node. wgxpath (and M.S. Edge) only match to TEXT_NODE type so 
CDATA sections are treated as non-text.

Here is a jsfiddle that shows how wgxpath 1.3.0 gives unexpected results
https://jsfiddle.net/r73me5er/11/
